### PR TITLE
Mage: add Frostfire / Frostfire AOE / Firestarter controls + locales

### DIFF
--- a/Locales/MultiBotLanguage-deDE.lua
+++ b/Locales/MultiBotLanguage-deDE.lua
@@ -2145,6 +2145,29 @@ MultiBot.tips.mage.playbook.fire =
 "|cffff0000Linksklicken um Feuer-Magie ein- oder auszuschalten|r\n"..
 "|cf9999999(Ausführreihenfolge: Bot)|r";
 
+MultiBot.tips.mage.playbook.frostfireAoe =
+"Frostfire AOE|cffffffff\n"..
+"Aktiviert die Frostfire- + AOE-Kampfstrategien.\n"..
+"DPS-AOE, DPS-Assist und Tank-Assist schließen sich gegenseitig aus.\n"..
+"Nur einer dieser Modi kann aktiv sein.|r\n\n"..
+"|cffff0000Linksklick zum Aktivieren/Deaktivieren von Frostfire AOE|r\n"..
+"|cf9999999(Ausführungsreihenfolge: Bot)|r";
+
+MultiBot.tips.mage.playbook.frostfire =
+"Frostfire|cffffffff\n"..
+"Aktiviert die Frostfire-Einzelziel-Kampfstrategie.\n"..
+"Arkan, Frost, Feuer und Frostfire schließen sich gegenseitig aus.\n"..
+"Nur eine Spezialisierung kann aktiv sein.|r\n\n"..
+"|cffff0000Linksklick zum Aktivieren/Deaktivieren von Frostfire|r\n"..
+"|cf9999999(Ausführungsreihenfolge: Bot)|r";
+
+MultiBot.tips.mage.playbook.firestarter =
+"Firestarter|cffffffff\n"..
+"Aktiviert die \"Firestarter\"-Taktik für Feuerspielweise (Opener/Sofortzauber).\n"..
+"Kann mit deiner aktuellen Spezialisierung und AOE-Einstellungen kombiniert werden.|r\n\n"..
+"|cffff0000Linksklick zum Aktivieren/Deaktivieren von Firestarter|r\n"..
+"|cf9999999(Ausführungsreihenfolge: Bot)|r";
+
 MultiBot.tips.mage.dps.master =
 "DPS-Control|cffffffff\n"..
 "Mit dieser Steuereinheit legt man die generelle DPS-Strategie fest.|r\n\n"..

--- a/Locales/MultiBotLanguage-enGB.lua
+++ b/Locales/MultiBotLanguage-enGB.lua
@@ -2093,6 +2093,29 @@ MultiBot.tips.mage.playbook.fire =
 "|cffff0000Left-click to toggle|r\n"..
 "|cf9999999(Executed by: Bot)|r";
 
+MultiBot.tips.mage.playbook.frostfireAoe =
+"Frostfire AOE|cffffffff\n"..
+"Enables the Frostfire + AOE combat strategies.\n"..
+"DPS-AOE, DPS-Assist and Tank-Assist are mutually exclusive.\n"..
+"Only one of these can be active.|r\n\n"..
+"|cffff0000Left-Click to enable or disable Frostfire AOE|r\n"..
+"|cf9999999(Execution-Order: Bot)|r";
+
+MultiBot.tips.mage.playbook.frostfire =
+"Frostfire|cffffffff\n"..
+"Enables the Frostfire single-target combat strategy.\n"..
+"Arcane, Frost, Fire and Frostfire are mutually exclusive.\n"..
+"Only one spec can be active.|r\n\n"..
+"|cffff0000Left-Click to enable or disable Frostfire|r\n"..
+"|cf9999999(Execution-Order: Bot)|r";
+
+MultiBot.tips.mage.playbook.firestarter =
+"Firestarter|cffffffff\n"..
+"Enables the \"Firestarter\" tactic for Fire gameplay (opener/instant casts).\n"..
+"Can be combined with your current spec and AOE settings.|r\n\n"..
+"|cffff0000Left-Click to enable or disable Firestarter|r\n"..
+"|cf9999999(Execution-Order: Bot)|r";
+
 MultiBot.tips.mage.dps.master =
 "Main Mage DPS|cffffffff\n"..
 "General Mage DPS strategies|r\n\n"..

--- a/Locales/MultiBotLanguage-enUS.lua
+++ b/Locales/MultiBotLanguage-enUS.lua
@@ -2097,6 +2097,29 @@ MultiBot.tips.mage.playbook.fire =
 "|cffff0000Left-click to toggle|r\n"..
 "|cf9999999(Executed by: Bot)|r";
 
+MultiBot.tips.mage.playbook.frostfireAoe =
+"Frostfire AOE|cffffffff\n"..
+"Enables the Frostfire + AOE combat strategies.\n"..
+"DPS-AOE, DPS-Assist and Tank-Assist are mutually exclusive.\n"..
+"Only one of these can be active.|r\n\n"..
+"|cffff0000Left-Click to enable or disable Frostfire AOE|r\n"..
+"|cf9999999(Execution-Order: Bot)|r";
+
+MultiBot.tips.mage.playbook.frostfire =
+"Frostfire|cffffffff\n"..
+"Enables the Frostfire single-target combat strategy.\n"..
+"Arcane, Frost, Fire and Frostfire are mutually exclusive.\n"..
+"Only one spec can be active.|r\n\n"..
+"|cffff0000Left-Click to enable or disable Frostfire|r\n"..
+"|cf9999999(Execution-Order: Bot)|r";
+
+MultiBot.tips.mage.playbook.firestarter =
+"Firestarter|cffffffff\n"..
+"Enables the \"Firestarter\" tactic for Fire gameplay (opener/instant casts).\n"..
+"Can be combined with your current spec and AOE settings.|r\n\n"..
+"|cffff0000Left-Click to enable or disable Firestarter|r\n"..
+"|cf9999999(Execution-Order: Bot)|r";
+
 MultiBot.tips.mage.dps.master =
 "Main Mage DPS|cffffffff\n"..
 "General Mage DPS strategies|r\n\n"..

--- a/Locales/MultiBotLanguage-esES.lua
+++ b/Locales/MultiBotLanguage-esES.lua
@@ -2150,6 +2150,29 @@ MultiBot.tips.mage.playbook.fire =
 "|cffff0000Clic izquierdo para activar o desactivar Fire-Magic|r\n"..
 "|cff999999(Orden de ejecución: Bot)|r";
 
+MultiBot.tips.mage.playbook.frostfireAoe =
+"Frostfire AOE|cffffffff\n"..
+"Habilita las estrategias de combate Frostfire + AOE.\n"..
+"DPS-AOE, DPS-Assist y Tank-Assist son mutuamente excluyentes.\n"..
+"Solo uno de estos modos puede estar activo.|r\n\n"..
+"|cffff0000Clic izquierdo para activar o desactivar Frostfire AOE|r\n"..
+"|cf9999999(Orden de ejecución: Bot)|r";
+
+MultiBot.tips.mage.playbook.frostfire =
+"Frostfire|cffffffff\n"..
+"Habilita la estrategia de combate Frostfire de un solo objetivo.\n"..
+"Arcano, Escarcha, Fuego y Frostfire son mutuamente excluyentes.\n"..
+"Solo una especialización puede estar activa.|r\n\n"..
+"|cffff0000Clic izquierdo para activar o desactivar Frostfire|r\n"..
+"|cf9999999(Orden de ejecución: Bot)|r";
+
+MultiBot.tips.mage.playbook.firestarter =
+"Firestarter|cffffffff\n"..
+"Habilita la táctica \"Firestarter\" para la rama de Fuego (apertura/lanzamientos instantáneos).\n"..
+"Se puede combinar con tu especialización y la configuración de AOE.|r\n\n"..
+"|cffff0000Clic izquierdo para activar o desactivar Firestarter|r\n"..
+"|cf9999999(Orden de ejecución: Bot)|r";
+
 MultiBot.tips.mage.dps.master =
 "DPS-Control|cffffffff\n"..  -- Línea en inglés
 "En el DPS-Control encontrarás las estrategias de daño general.|r\n\n"..

--- a/Locales/MultiBotLanguage-frFR.lua
+++ b/Locales/MultiBotLanguage-frFR.lua
@@ -2161,6 +2161,29 @@ MultiBot.tips.mage.playbook.fire =
 "|cffff0000Clic gauche pour activer ou désactiver la magie de feu|r\n"..
 "|cff999999(Ordre d'exécution : Bot)|r";
 
+MultiBot.tips.mage.playbook.frostfireAoe =
+"GivreFeu AOE|cffffffff\n"..
+"Active les stratégies de combat GivreFeu + AOE.\n"..
+"DPS-AOE, DPS-Assist et Tank-Assist sont mutuellement exclusifs.\n"..
+"Un seul de ces modes peut être actif.|r\n\n"..
+"|cffff0000Clic-Gauche pour activer ou désactiver Frostfire AOE|r\n"..
+"|cf9999999(Ordre d’exécution : Bot)|r";
+
+MultiBot.tips.mage.playbook.frostfire =
+"GivreFeu|cffffffff\n"..
+"Active la stratégie de combat GivreFeu mono-cible.\n"..
+"Arcane, Givre, Feu et GivreFeu sont mutuellement exclusifs.\n"..
+"Une seule spécialisation peut être active.|r\n\n"..
+"|cffff0000Clic-Gauche pour activer ou désactiver Frostfire|r\n"..
+"|cf9999999(Ordre d’exécution : Bot)|r";
+
+MultiBot.tips.mage.playbook.firestarter =
+"Firestarter|cffffffff\n"..
+"Active la tactique \"Firestarter\" pour le gameplay Feu (ouverture/incantations instantanées).\n"..
+"Peut être combiné avec votre spécialisation et l’option AOE.|r\n\n"..
+"|cffff0000Clic-Gauche pour activer ou désactiver Firestarter|r\n"..
+"|cf9999999(Ordre d’exécution : Bot)|r";
+
 MultiBot.tips.mage.dps.master =
 "Contrôle DPS|cffffffff\n"..
 "Dans le contrôle DPS, vous trouverez les stratégies DPS générales.|r\n\n"..

--- a/Locales/MultiBotLanguage-koKR.lua
+++ b/Locales/MultiBotLanguage-koKR.lua
@@ -2144,6 +2144,29 @@ MultiBot.tips.mage.playbook.fire =
 "|cffff0000왼쪽 클릭으로 화염 마법을 활성화 또는 비활성화합니다|r\n"..
 "|cf9999999(명령 실행: 로봇)|r";
 
+MultiBot.tips.mage.playbook.frostfireAoe =
+"Frostfire AOE|cffffffff\n"..
+"Frostfire + AOE 전투 전략을 활성화합니다.\n"..
+"DPS-AOE, DPS-Assist, Tank-Assist는 서로 배타적입니다.\n"..
+"이 모드 중 하나만 활성화할 수 있습니다.|r\n\n"..
+"|cffff0000왼쪽-클릭으로 Frostfire AOE 켜기/끄기|r\n"..
+"|cf9999999(실행 순서: 봇)|r";
+
+MultiBot.tips.mage.playbook.frostfire =
+"Frostfire|cffffffff\n"..
+"단일 대상 Frostfire 전투 전략을 활성화합니다.\n"..
+"Arcane, Frost, Fire, Frostfire는 서로 배타적입니다.\n"..
+"하나의 전문화만 활성화할 수 있습니다.|r\n\n"..
+"|cffff0000왼쪽-클릭으로 Frostfire 켜기/끄기|r\n"..
+"|cf9999999(실행 순서: 봇)|r";
+
+MultiBot.tips.mage.playbook.firestarter =
+"Firestarter|cffffffff\n"..
+"화염 운용을 위한 \"Firestarter\" 전술을 활성화합니다(오프너/즉시 시전).\n"..
+"현재 전문화 및 AOE 설정과 함께 사용할 수 있습니다.|r\n\n"..
+"|cffff0000왼쪽-클릭으로 Firestarter 켜기/끄기|r\n"..
+"|cf9999999(실행 순서: 봇)|r";
+
 MultiBot.tips.mage.dps.master =
 "DPS 제어|cffffffff\n"..
 "이 제어 장치를 사용하여 공통 DPS 전략을 설정합니다.|r\n\n"..

--- a/Locales/MultiBotLanguage-ruRU.lua
+++ b/Locales/MultiBotLanguage-ruRU.lua
@@ -2145,6 +2145,29 @@ MultiBot.tips.mage.playbook.fire =
 "|cffff0000Левый клик - вкл/выкл огненную магию|r\n"..
 "|cf9999999(Порядок выполнения: Бот)|r";
 
+MultiBot.tips.mage.playbook.frostfireAoe =
+"Frostfire AOE|cffffffff\n"..
+"Включает боевые стратегии Frostfire + AOE.\n"..
+"DPS-AOE, DPS-Assist и Tank-Assist взаимоисключают друг друга.\n"..
+"Активным может быть только один из этих режимов.|r\n\n"..
+"|cffff0000ЛКМ — включить/выключить Frostfire AOE|r\n"..
+"|cf9999999(Порядок выполнения: Бот)|r";
+
+MultiBot.tips.mage.playbook.frostfire =
+"Frostfire|cffffffff\n"..
+"Включает однопользовательскую боевую стратегию Frostfire.\n"..
+"Arcane, Frost, Fire и Frostfire взаимно исключают друг друга.\n"..
+"Активной может быть только одна специализация.|r\n\n"..
+"|cffff0000ЛКМ — включить/выключить Frostfire|r\n"..
+"|cf9999999(Порядок выполнения: Бот)|r";
+
+MultiBot.tips.mage.playbook.firestarter =
+"Firestarter|cffffffff\n"..
+"Включает тактику \"Firestarter\" для школы Огня (опенер/мгновенные заклинания).\n"..
+"Можно сочетать с текущей специализацией и параметрами AOE.|r\n\n"..
+"|cffff0000ЛКМ — включить/выключить Firestarter|r\n"..
+"|cf9999999(Порядок выполнения: Бот)|r";
+
 MultiBot.tips.mage.dps.master =
 "Управление DPS|cffffffff\n"..
 "Содержит основные DPS-стратегии.|r\n\n"..

--- a/Locales/MultiBotLanguage-zhCN.lua
+++ b/Locales/MultiBotLanguage-zhCN.lua
@@ -2073,7 +2073,7 @@ MultiBot.tips.hunter.tankAssist =
 "|cffff0000左键单击以启用或禁用坦克辅助|r\n"..
 "|cf9999999(执行命令: 机器人)|r";
 
--- 法师 --
+-- MAGE --
 
 MultiBot.tips.mage.buff.master =
 "增益控制|cffffffff\n"..
@@ -2142,6 +2142,29 @@ MultiBot.tips.mage.playbook.fire =
 "只能激活这些策略中的一种。|r\n\n"..
 "|cffff0000左键点击启用或禁用火焰魔法|r\n"..
 "|cf9999999(执行命令: 机器人)|r";
+
+MultiBot.tips.mage.playbook.frostfireAoe =
+"Frostfire AOE|cffffffff\n"..
+"启用 Frostfire + AOE 作战策略。\n"..
+"DPS-AOE、DPS-Assist 与 Tank-Assist 互斥。\n"..
+"这些模式中只能激活一个。|r\n\n"..
+"|cffff0000左键点击以启用/停用 Frostfire AOE|r\n"..
+"|cf9999999（执行顺序：Bot）|r";
+
+MultiBot.tips.mage.playbook.frostfire =
+"Frostfire|cffffffff\n"..
+"启用单体 Frostfire 作战策略。\n"..
+"Arcane、Frost、Fire 与 Frostfire 互斥。\n"..
+"只能激活一个专精。|r\n\n"..
+"|cffff0000左键点击以启用/停用 Frostfire|r\n"..
+"|cf9999999（执行顺序：Bot）|r";
+
+MultiBot.tips.mage.playbook.firestarter =
+"Firestarter|cffffffff\n"..
+"为火焰流派启用\"Firestarter\"战术（起手/瞬发）。\n"..
+"可与当前专精与 AOE 设置组合使用。|r\n\n"..
+"|cffff0000左键点击以启用/停用 Firestarter|r\n"..
+"|cf9999999（执行顺序：Bot）|r";
 
 MultiBot.tips.mage.dps.master =
 "DPS控制|cffffffff\n"..

--- a/MultiBot.lua
+++ b/MultiBot.lua
@@ -2532,6 +2532,29 @@ MultiBot.tips.mage.playbook.fire =
 "|cffff0000Left-Click to enable or disable Fire-Magic|r\n"..
 "|cf9999999(Execution-Order: Bot)|r";
 
+MultiBot.tips.mage.playbook.frostfireAoe =
+"Frostfire AOE|cffffffff\n"..
+"Enables the Frostfire + AOE combat strategies.\n"..
+"DPS-AOE, DPS-Assist and Tank-Assist are mutually exclusive.\n"..
+"Only one of these can be active.|r\n\n"..
+"|cffff0000Left-Click to enable or disable Frostfire AOE|r\n"..
+"|cf9999999(Execution-Order: Bot)|r";
+
+MultiBot.tips.mage.playbook.frostfire =
+"Frostfire|cffffffff\n"..
+"Enables the Frostfire single-target combat strategy.\n"..
+"Arcane, Frost, Fire and Frostfire are mutually exclusive.\n"..
+"Only one spec can be active.|r\n\n"..
+"|cffff0000Left-Click to enable or disable Frostfire|r\n"..
+"|cf9999999(Execution-Order: Bot)|r";
+
+MultiBot.tips.mage.playbook.firestarter =
+"Firestarter|cffffffff\n"..
+"Enables the \"Firestarter\" tactic for Fire gameplay (opener/instant casts).\n"..
+"Can be combined with your current spec and AOE settings.|r\n\n"..
+"|cffff0000Left-Click to enable or disable Firestarter|r\n"..
+"|cf9999999(Execution-Order: Bot)|r";
+
 MultiBot.tips.mage.dps.master =
 "DPS-Control|cffffffff\n"..
 "In the DPS-Control you will find the general DPS-Strategies.|r\n\n"..

--- a/MultiBotMage.lua
+++ b/MultiBotMage.lua
@@ -83,6 +83,25 @@ MultiBot.addMage = function(pFrame, pCombat, pNormal)
 			pButton.getButton("Frost").setDisable()
 		end
 	end
+	-- missing Frostfire & Firestarter --
+	tFrame.addButton("FrostFireAoe", 0, 156, "ability_mage_frostfirebolt", MultiBot.tips.mage.playbook.frostfireAoe).setDisable()
+	.doLeft = function(pButton)
+		MultiBot.OnOffActionToTarget(pButton, "co +frostfire aoe,?", "co -frostfire aoe,?", pButton.getName())
+	end
+
+	tFrame.addButton("FrostFire", 0, 182, "ability_mage_frostfirebolt", MultiBot.tips.mage.playbook.frostfire).setDisable()
+	.doLeft = function(pButton)
+		if(MultiBot.OnOffActionToTarget(pButton, "co +frostfire,?", "co -frostfire,?", pButton.getName())) then
+			pButton.getButton("Arcane").setDisable()
+			pButton.getButton("Frost").setDisable()
+			pButton.getButton("Fire").setDisable()
+		end
+	end
+
+	tFrame.addButton("Firestarter", 0, 208, "ability_mage_firestarter", MultiBot.tips.mage.playbook.firestarter).setDisable()
+	.doLeft = function(pButton)
+		MultiBot.OnOffActionToTarget(pButton, "co +firestarter,?", "co -firestarter,?", pButton.getName())
+	end
 	
 	-- STRATEGIES:PLAYBOOK --
 	
@@ -92,6 +111,9 @@ MultiBot.addMage = function(pFrame, pCombat, pNormal)
 	if(MultiBot.isInside(pCombat, "frost,")) then pFrame.getButton("Frost").setEnable() end
 	if(MultiBot.isInside(pCombat, "fire aoe")) then pFrame.getButton("FireAoe").setEnable() end
 	if(MultiBot.isInside(pCombat, "fire,")) then pFrame.getButton("Fire").setEnable() end
+	if(MultiBot.isInside(pCombat, "frostfire aoe")) then pFrame.getButton("FrostFireAoe").setEnable() end
+	if(MultiBot.isInside(pCombat, "frostfire,")) then pFrame.getButton("FrostFire").setEnable() end
+	if(MultiBot.isInside(pCombat, "firestarter")) then pFrame.getButton("Firestarter").setEnable() end
 	
 	-- DPS --
 	


### PR DESCRIPTION
Summary
Brings MultiBot Mage UI to parity with Playerbots by exposing the missing strategies:

Frostfire → co +frostfire

Frostfire AOE → co +frostfire aoe

Firestarter → co +firestarter

Includes tooltips for enUS, frFR, deDE, esES, ruRU, koKR, zhCN.

Why
MultiBotMage.lua did not surface Frostfire (single-target), its AOE variant, nor the Firestarter tactic, while they exist in Playerbots. This closes the feature gap and lets users toggle these directly from the UI.

Details

Added three buttons in the Mage “Playbook” section with state sync using MultiBot.isInside(...).

Localized tooltip strings for all supported languages.