### PR TITLE
Compatibility issue with add on mapster

### DIFF
--- a/Core/MultiBot.lua
+++ b/Core/MultiBot.lua
@@ -18,7 +18,7 @@ end
 function MultiBot.PromoteFrame(f, strata)
   if not f or not f.SetFrameStrata then return end
   -- Add a default fallback kept at "DIALOG" to avoid regressions and it's safer
-  local level = strata or (MultiBotGlobalSave and MultiBotGlobalSave["Strata.Level"]) or "DIALOG"
+  local level = strata or (MultiBotGlobalSave and MultiBotGlobalSave["Strata.Level"]) or "HIGH"
   f:SetFrameStrata(level)
   if f.SetToplevel then f:SetToplevel(true) end
   if f.HookScript then

--- a/UI/MultiBotOptions.lua
+++ b/UI/MultiBotOptions.lua
@@ -110,7 +110,7 @@ function MultiBot.BuildOptionsPanel()
     strataLabel:SetPoint("BOTTOMLEFT", strataDropDown, "TOPLEFT", 16, 3)
     strataLabel:SetText("Frame Strata")
 
-    local current = (MultiBotGlobalSave and MultiBotGlobalSave["Strata.Level"]) or "DIALOG"
+    local current = (MultiBotGlobalSave and MultiBotGlobalSave["Strata.Level"]) or "HIGH"
     local strataLevels = { "BACKGROUND", "LOW", "MEDIUM", "HIGH", "DIALOG", "TOOLTIP" }
 
     local function OnClick(button)


### PR DESCRIPTION
When using Multibot in addition with mapster than MB is over the WorldMap.
<img width="2880" height="1920" alt="Screenshot 2025-09-29 231107" src="https://github.com/user-attachments/assets/4ef78d38-b287-4e97-b94b-88a9e8c1be47" />

Changed standard strata to HIGH.
That solves this issue.
All other windows of MB retain the value "DIALOG", only the MultiBot-bar has the value "HIGH" and this is changable in the config of MB.

I tested the game with this setting for a while now and i don't have any issues with this.