### PR TITLE
Fix for when a client doesn't have the item

### DIFF
--- a/Core/MultiBotEngine.lua
+++ b/Core/MultiBotEngine.lua
@@ -202,11 +202,11 @@ end
 MultiBot.SafeTexturePath = function(pTexture)
 	-- Guard: nil or non-string => fallback
 	if type(pTexture) ~= "string" or pTexture == "" then
-		return "Interface\\Icons\\INV_Misc_QuestionMark"
+		return "Interface/Icons/INV_Misc_QuestionMark"
 	end
 	-- Normalize: only prefix when not already an Interface path
-	local head = string.sub(pTexture, 1, 9)
-	local needsPrefix = not (head == "Interface" or head == "INTERFACE")
+    local head = string.sub(pTexture, 1, 9)
+    local needsPrefix = string.lower(head) ~= "interface"
 	if needsPrefix then
 		return "Interface/Icons/" .. pTexture
 	end

--- a/Core/MultiBotEngine.lua
+++ b/Core/MultiBotEngine.lua
@@ -197,6 +197,22 @@ MultiBot.isUnit = function(pUnit)
 	return true
 end
 
+-- Safe texture resolver to avoid calling string.sub on nil and to normalize paths
+-- Returns a usable texture path string. Falls back to the question mark icon.
+MultiBot.SafeTexturePath = function(pTexture)
+	-- Guard: nil or non-string => fallback
+	if type(pTexture) ~= "string" or pTexture == "" then
+		return "Interface\\Icons\\INV_Misc_QuestionMark"
+	end
+	-- Normalize: only prefix when not already an Interface path
+	local head = string.sub(pTexture, 1, 9)
+	local needsPrefix = not (head == "Interface" or head == "INTERFACE")
+	if needsPrefix then
+		return "Interface/Icons/" .. pTexture
+	end
+	return pTexture
+end
+
 --[[MultiBot.toClass = function(pClass)
 	local pLower = string.lower(pClass)
 	local pStart = string.sub(pLower, 1, 5)
@@ -593,7 +609,7 @@ MultiBot.newFrame = function(pParent, pX, pY, pSize, oWidth, oHeight, oAlign)
 	frame.addTexture = function(pTexture)
 		if(frame.texture ~= nil) then frame.texture:Hide() end
 		frame.texture = frame:CreateTexture(nil, "BACKGROUND")
-		frame.texture:SetTexture(MultiBot.IF(string.sub(pTexture, 1, 9) ~= "Interface", "Interface/Icons/", "") .. pTexture)
+		frame.texture:SetTexture(MultiBot.SafeTexturePath(pTexture))
 		frame.texture:SetAllPoints(frame)
 		frame.texture:Show()
 		return frame.texture
@@ -670,7 +686,7 @@ MultiBot.newFrame = function(pParent, pX, pY, pSize, oWidth, oHeight, oAlign)
 	end
 	
 	frame.setTexture = function(pTexture)
-		frame.texture:SetTexture(MultiBot.IF(string.sub(pTexture, 1, 9) ~= "Interface", "Interface/Icons/", "") .. pTexture)
+		frame.texture:SetTexture(MultiBot.SafeTexturePath(pTexture))
 		frame.texture:SetAllPoints(frame)
 		frame.texture:Show()
 		return frame
@@ -759,7 +775,7 @@ MultiBot.newButton = function(pParent, pX, pY, pSize, pTexture, pTip, oTemplate)
 	button:Show()
 	
 	button.icon = button:CreateTexture(nil, "BACKGROUND")
-	button.icon:SetTexture(MultiBot.IF(string.sub(pTexture, 1, 9) ~= "Interface", "Interface/Icons/", "") .. pTexture)
+	button.icon:SetTexture(MultiBot.SafeTexturePath(pTexture))
 	button.icon:SetAllPoints(button)
 	button.icon:Show()
 	
@@ -775,7 +791,7 @@ MultiBot.newButton = function(pParent, pX, pY, pSize, pTexture, pTip, oTemplate)
 	button:SetPushedTexture("Interface/Buttons/UI-Quickslot-Depress")
 	button:SetNormalTexture("")
 	
-	button.texture = pTexture
+	button.texture = MultiBot.SafeTexturePath(pTexture)
 	button.parent = pParent
 	button.size = pSize
 	button.tip = pTip
@@ -800,17 +816,17 @@ MultiBot.newButton = function(pParent, pX, pY, pSize, pTexture, pTip, oTemplate)
 	end
 	
 	button.setButton = function(pTexture, pTip)
-		button.icon:SetTexture(MultiBot.IF(string.sub(pTexture, 1, 9) ~= "Interface", "Interface/Icons/", "") .. pTexture)
+		button.icon:SetTexture(MultiBot.SafeTexturePath(pTexture))
 		button.icon:SetAllPoints(button)
-		button.texture = pTexture
+		button.texture = MultiBot.SafeTexturePath(pTexture)
 		button.tip = pTip
 		return button
 	end
 	
 	button.setTexture = function(pTexture)
-		button.icon:SetTexture(MultiBot.IF(string.sub(pTexture, 1, 9) ~= "Interface", "Interface/Icons/", "") .. pTexture)
+		button.icon:SetTexture(MultiBot.SafeTexturePath(pTexture))
 		button.icon:SetAllPoints(button)
-		button.texture = pTexture
+		button.texture = MultiBot.SafeTexturePath(pTexture)
 		return button
 	end
 	

--- a/UI/MultiBotItem.lua
+++ b/UI/MultiBotItem.lua
@@ -7,7 +7,7 @@ MultiBot.addItem = function(pFrame, pInfo)
 	
 	-- Fallback icon if not cached/known yet
 	if tIcon == nil or tIcon == "" then
-		tIcon = "INV_Misc_QuestionMark"
+		tIcon = MultiBot.SafeTexturePath("INV_Misc_QuestionMark")
 	end
 	
 	local tX = (pFrame.index%8) * 38

--- a/UI/MultiBotItem.lua
+++ b/UI/MultiBotItem.lua
@@ -5,6 +5,11 @@ MultiBot.addItem = function(pFrame, pInfo)
 	local tIcon = GetItemIcon(tID)
 	local tName, tLink, tRare = GetItemInfo(tID)
 	
+	-- Fallback icon if not cached/known yet
+	if tIcon == nil or tIcon == "" then
+		tIcon = "INV_Misc_QuestionMark"
+	end
+	
 	local tX = (pFrame.index%8) * 38
 	local tY = math.floor(pFrame.index/8) * -37.1
 	


### PR DESCRIPTION
When opening a bots inventory the addon would error if the client does not have the icon for the item.
eg, I use this module https://github.com/silviu20092/mod-flightmaster-whistle which uses a custom item.