### PR TITLE
Fix Raidus remove doesn't update main menu

### DIFF
--- a/Features/MultiBotRaidus.lua
+++ b/Features/MultiBotRaidus.lua
@@ -689,7 +689,7 @@ MultiBot.raidus.setRaidus = function()
                 if MultiBotRaidusIsBotGrouped(name) then
                     -- Bot déjà dans le groupe/raid :
                     -- on laisse le core playerbots gérer leave + logout
-                    SendChatMessage("logout", "WHISPER", nil, name)
+                    SendChatMessage(".playerbot bot remove " .. name, "SAY")
                 else
                     -- Bot pas dans le groupe/raid :
                     -- login + invite via playerbots


### PR DESCRIPTION
### Problem
Right clicking a bot in raidus will log the bot out but the main menu doesnt update to show the bot is logged out

### Fix
Use .playerbot bot remove instead of logout for Raidus bot removal
This updates the main menu to show the bot is now offline